### PR TITLE
Add missing Rate Providers to the registry

### DIFF
--- a/rate-providers/registry.json
+++ b/rate-providers/registry.json
@@ -107,6 +107,14 @@
                 }
             ]
         },
+        "0xA6aeD7922366611953546014A3f9e93f058756a2": {
+            "name": "QueenRateProvider",
+            "summary": "safe",
+            "review": "./QueenRateProvider.md",
+            "warnings": [],
+            "factory": "",
+            "upgradeableComponents": []
+        },
         "0x67560A970FFaB46D65cB520dD3C2fF4E684f29c2": {
             "name": "TBYRateProvider",
             "summary": "safe",
@@ -127,6 +135,14 @@
             "name": "SavingsDAIRateProvider",
             "summary": "safe",
             "review": "./SavingsDAIRateProvider.md",
+            "warnings": [],
+            "factory": "",
+            "upgradeableComponents": []
+        },
+        "0xd8689E8740C23d73136744817347fd6aC464E842": {
+            "name": "wUSDKRateProvider",
+            "summary": "safe",
+            "review": "./wUSDKRateProvider.md",
             "warnings": [],
             "factory": "",
             "upgradeableComponents": []

--- a/rate-providers/registry.json
+++ b/rate-providers/registry.json
@@ -111,7 +111,9 @@
             "name": "QueenRateProvider",
             "summary": "safe",
             "review": "./QueenRateProvider.md",
-            "warnings": [],
+            "warnings": [
+                "donation"
+            ],
             "factory": "",
             "upgradeableComponents": []
         },
@@ -143,7 +145,9 @@
             "name": "wUSDKRateProvider",
             "summary": "safe",
             "review": "./wUSDKRateProvider.md",
-            "warnings": [],
+            "warnings": [
+                "donation"
+            ],
             "factory": "",
             "upgradeableComponents": []
         }

--- a/rate-providers/wUSDKRateProvider.md
+++ b/rate-providers/wUSDKRateProvider.md
@@ -4,7 +4,7 @@
 - Reviewed by: @baileyspraggins
 - Checked by: @gerrrg 
 - Deployed at:
-    - [eth:0xd8689E8740C23d73136744817347fd6aC464E842>](https://etherscan.io/address/0xd8689E8740C23d73136744817347fd6aC464E842)
+    - [eth:0xd8689E8740C23d73136744817347fd6aC464E842](https://etherscan.io/address/0xd8689E8740C23d73136744817347fd6aC464E842)
 - Audit report(s):
     - [Kuma Protocol](https://docs.kuma.bond/kuma-protocol/ressources/security-and-audits)
 


### PR DESCRIPTION
This PR adds missing RateProviders to the registry that have already been reviewed. 

RateProviders added:
- `QueenRateProvider`
- `wUSKRateProvider`